### PR TITLE
feat: allow injecting custom GraphQLCache for Storefront/Admin clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.8.0
+* Added `cache` and `adminCache` optional parameters to `ShopifyConfig.setConfig`, allowing callers to inject a custom `GraphQLCache` (e.g. backed by `HiveStore` for disk persistence) for the Storefront and Admin API clients. Defaults preserve the previous in-memory behaviour.
+
 # 2.7.0
 * Added category information in all product related gql.
 * Updated example to show the product category

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ void main() {
 
      // Store locale | default : en
     language: 'en',
+
+    // optional | default: in-memory GraphQLCache()
+    // Inject a custom GraphQLCache for the Storefront client (e.g. disk-backed
+    // via HiveStore from graphql_flutter).
+    // cache: GraphQLCache(store: await HiveStore.open()),
+
+    // optional | default: in-memory GraphQLCache()
+    // Inject a custom GraphQLCache for the Admin client.
+    // adminCache: GraphQLCache(store: await HiveStore.open(boxName: 'admin')),
   );
   
   runApp(MyApp());
@@ -46,6 +55,8 @@ If you are not using that function, you may not need to provide it.
 > `storefrontApiVersion` default vesion is set to '2024-07'
 
 > `language` defaults to 'en'. It is the default locale/language of the store. Only takes effect if the store supports provided language code.
+
+> `cache` / `adminCache` let you supply a `GraphQLCache` from `graphql_flutter` so query results can be persisted to disk (e.g. via `HiveStore`) and survive app restarts. When omitted, fresh in-memory caches are created as before.
 
 <hr>
 

--- a/lib/shopify_config.dart
+++ b/lib/shopify_config.dart
@@ -88,6 +88,13 @@ class ShopifyConfig {
   ///
   /// [countryCode] is optional, but defaults to null.
   /// Used to change currency units. eg: "US", "NP", "JP" etc. Only takes effect if the store supports provided currency.
+  ///
+  /// [cache] is optional. Inject a custom [GraphQLCache] (e.g. backed by
+  /// `HiveStore` for disk persistence) for the Storefront API client.
+  /// Defaults to a new in-memory [GraphQLCache] when omitted.
+  ///
+  /// [adminCache] is optional. Inject a custom [GraphQLCache] for the Admin
+  /// API client. Defaults to a new in-memory [GraphQLCache] when omitted.
   static void setConfig({
     required String storefrontAccessToken,
     required String storeUrl,
@@ -95,6 +102,8 @@ class ShopifyConfig {
     String storefrontApiVersion = "2024-07",
     CachePolicy? cachePolicy,
     String? language,
+    GraphQLCache? cache,
+    GraphQLCache? adminCache,
   }) {
     _storefrontAccessToken = storefrontAccessToken;
     _adminAccessToken = adminAccessToken;
@@ -109,7 +118,7 @@ class ShopifyConfig {
           'Accept-Language': language ?? 'en',
         },
       ),
-      cache: GraphQLCache(),
+      cache: cache ?? GraphQLCache(),
     );
 
     _graphQLClientAdmin = _adminAccessToken == null
@@ -122,7 +131,7 @@ class ShopifyConfig {
                 'Accept-Language': language ?? 'en',
               },
             ),
-            cache: GraphQLCache(),
+            cache: adminCache ?? GraphQLCache(),
           );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shopify_flutter
 description: A Flutter package to seamlessly connect your Shopify store with your app.
-version: 2.7.0
+version: 2.8.0
 repository: https://github.com/imsujan276/shopify_flutter
 issue_tracker: https://github.com/imsujan276/shopify_flutter/issues
 


### PR DESCRIPTION
Add optional `cache` and `adminCache` parameters to `ShopifyConfig.setConfig` so callers can provide a `GraphQLCache` (e.g. backed by `HiveStore`) and persist GraphQL responses to disk. Defaults preserve the prior in-memory behaviour for full backwards compatibility.